### PR TITLE
feat: prefer serena tools over native tools

### DIFF
--- a/.serena/memories/tool_preference.md
+++ b/.serena/memories/tool_preference.md
@@ -1,0 +1,1 @@
+This project prefers Serena tools over the default Gemini native tools when an equivalent tool exists. This is to ensure that the project's specific configurations and symbolic language server features are used correctly. For example, prefer `serena.list_dir` over `default_api.list_directory`.


### PR DESCRIPTION
This PR adds a memory to prefer Serena tools over Gemini native tools. This is to ensure that the project's specific configurations and symbolic language server features are used correctly.