### PR TITLE
feat(ai): add confidence score to task creation

### DIFF
--- a/AIAnalyzer.ts
+++ b/AIAnalyzer.ts
@@ -26,7 +26,14 @@ export interface PlanOfAction {
     due_date?: string; // YYYY-MM-DD format or natural language
     priority?: number; // 1 (Urgent) to 4 (Normal)
   };
+  confidence?: {
+    score: number;
+    reasoning: string;
+    not_higher_reasoning: string;
+    not_lower_reasoning: string;
+  };
 }
+
 
 export class AIAnalyzer {
   /**
@@ -104,6 +111,7 @@ export class AIAnalyzer {
       The "notes" fields must not be null or empty if the task is present.
       The "due_date" should be in YYYY-MM-DD format.
       The "priority" should be an integer from 1 (Urgent) to 4 (Normal).
+      For each thread, provide a confidence score (0-100) for the task creation decision. Explain why you gave that score, why it wasn't higher, and why it wasn't lower.
       ${config.task_service === 'Todoist' ? 'The "notes" field should be in proper Markdown format.' : ''}
     `;
 
@@ -141,6 +149,15 @@ export class AIAnalyzer {
                     notes: { type: "STRING" },
                     due_date: { type: "STRING" },
                     priority: { type: "NUMBER" },
+                  },
+                },
+                confidence: {
+                  type: "OBJECT",
+                  properties: {
+                    score: { type: "NUMBER" },
+                    reasoning: { type: "STRING" },
+                    not_higher_reasoning: { type: "STRING" },
+                    not_lower_reasoning: { type: "STRING" },
                   },
                 },
               },

--- a/Processor.ts
+++ b/Processor.ts
@@ -71,6 +71,19 @@ export class Processor {
       if (!plan.task.title) {
         plan.task.title = thread.getFirstMessageSubject();
       }
+
+      if (plan.confidence) {
+        const confidenceDetails = `
+--- 
+**Confidence Score:** ${plan.confidence.score}/100
+**Reasoning:** ${plan.confidence.reasoning}
+**Why not higher:** ${plan.confidence.not_higher_reasoning}
+**Why not lower:** ${plan.confidence.not_lower_reasoning}
+`;
+        plan.task.notes = `${plan.task.notes || ''}${confidenceDetails}`;
+        Logger.log(`Confidence for thread ${threadId}: ${confidenceDetails}`);
+      }
+
       Logger.log(`Creating task for thread ${threadId}: ${plan.task.title}`);
       const taskCreated = tasksManager.upsertTask(thread, plan.task, config);
       if (taskCreated) {


### PR DESCRIPTION
Adds a confidence score to the AI's task creation analysis. This score, along with the reasoning behind it, will be logged and added to the notes of any created tasks. Closes #18